### PR TITLE
Add a custom-header content type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ This renders to:
 Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n
 ```
 
+Another example configuration:
+```
+data "cloudinit_config" "foo" {
+  gzip = false
+  base64_encode = false
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "baz"
+  }
+  part {
+    content_type = "text/custom-header"
+    content = "baz=10"
+  }
+}
+```
+
+This renders to:
+
+```
+baz=10\nContent-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n
+```
+
 Developing the Provider
 ---------------------------
 


### PR DESCRIPTION
# Intro

As a developper at Outscale (Cloud Provider), we need to be able to add a ```custom-headers``` to the cloudinit config.<br>
Here is an example of what a custom header can be:<br><br>
```
-----BEGIN OUTSCALE SECTION-----
tags.osc.fcu.attract_server=front80
-----END OUTSCALE SECTION-----
```

# How to use it

You can use it with the following example:<br><br>
```
data "cloudinit_config" "config" {
  gzip          = false
  base64_encode = true
  part {
    content_type = "text/x-shellscript"
    content      = file("script.sh")
  }
  part {
    content_type = "text/custom-header"
    content      = file("my.custom.header")
  }
}
```
<br>
<br>
Of course, we can have multiple `part`of `text/custom-header`.

