### PR TITLE
feat: Add option to customize mime-type boundary

### DIFF
--- a/internal/provider/datasource_cloudinit_config_test.go
+++ b/internal/provider/datasource_cloudinit_config_test.go
@@ -58,6 +58,19 @@ func TestRender(t *testing.T) {
 			}`,
 			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n",
 		},
+		{
+			`data "cloudinit_config" "foo" {
+				gzip = false
+				base64_encode = false
+				boundary = "//"
+
+				part {
+					content_type = "text/x-shellscript"
+					content = "baz"
+				}
+			}`,
+			"Content-Type: multipart/mixed; boundary=\"//\"\nMIME-Version: 1.0\r\n\r\n--//\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--//--\r\n",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/website/docs/d/cloudinit_config.html.markdown
+++ b/website/docs/d/cloudinit_config.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 * `base64_encode` - (Optional) Base64 encoding of the rendered output. Defaults to `true`,
   and cannot be disabled if `gzip` is `true`.
 
+* `boundary` - (Optional) Define the Writer's default boundary separator. Defaults to `MIMEBOUNDARY`.
+
 * `part` - (Required) A nested block type which adds a file to the generated
   cloud-init configuration. Use multiple `part` blocks to specify multiple
   files, which will be included in order of declaration in the final MIME


### PR DESCRIPTION
Add an option to customize the MIME Boundary. Default is still `MIMEBOUNDARY`.

Resolves https://github.com/hashicorp/terraform-provider-cloudinit/issues/5