### PR TITLE
Add 0.15.1 to test matrix; bump all test Terraform versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.12.30'
-          - '0.13.6'
-          - '0.14.7'
+          - '0.12.31'
+          - '0.13.7'
+          - '0.14.11'
+          - '0.15.1'
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
Supersedes #21.