### PR TITLE
.github/workflows: Fix waiting-response label removal

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           labels: |
             stale
-            waiting-reply
+            waiting-response


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-cloudinit/labels/waiting-response