### PR TITLE
Use `github.ref` for tagging the latest commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           fetch-depth: 0
+          # Default input is the SHA that initially triggered the workflow. As we created a new commit in the previous job,
+          # to ensure we get the latest commit we use the ref for checkout: 'refs/heads/<branch_name>'
+          ref: ${{ github.ref }}
           # Avoid persisting GITHUB_TOKEN credentials as they take priority over our service account PAT for `git push` operations
           # More details: https://github.com/actions/checkout/blob/b4626ce19ce1106186ddf9bb20e706842f11a7c3/adrs/0153-checkout-v2.md#persist-credentials
           persist-credentials: false


### PR DESCRIPTION
### Background
As pointed out in https://github.com/hashicorp/setup-terraform/pull/300#discussion_r1113359792, the current GH workflow without the `git pull` step, will create a tag on the commit that **triggered the workflow**, which does not contain the merged changie logs.

### Notes
- Adds the ref name `refs/heads/main` to the `action/checkout` step for creating the release tag, to ensure it gets the latest commit

### References
- https://github.com/actions/checkout#usage
- https://github.com/actions/checkout/issues/461