### PR TITLE
Update workflow to have write permissions for goreleaser creation of GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 permissions:
-  contents: read # Write operations use service account PAT
+  contents: write # Needed for goreleaser to create GH release
 
 env:
   CI_COMMIT_AUTHOR: hc-github-team-tf-provider-devex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 permissions:
-  contents: write # Needed for goreleaser to create GH release
+  contents: read # Changelog commit operations use service account PAT
 
 env:
   CI_COMMIT_AUTHOR: hc-github-team-tf-provider-devex
@@ -102,6 +102,8 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [ release-notes ]
+    permissions:
+      contents: write # Needed for goreleaser to create GitHub release
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@106e6d08159ccec423310cc2c706bae59f46c09c # v2.2.0
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'


### PR DESCRIPTION
See error here: https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/4243307799

Goreleaser needs `write` permission to contents so it can create a new GitHub release