### PR TITLE
Revert "Update changelog" for `v2.3.0`

### DIFF
--- a/.changes/2.3.0.md
+++ b/.changes/2.3.0.md
@@ -1,6 +1,0 @@
-## 2.3.0 (February 22, 2023)
-
-NOTES:
-
-* provider: Rewritten to use the [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework) ([#96](https://github.com/hashicorp/terraform-provider-cloudinit/issues/96))
-

--- a/.changes/unreleased/NOTES-20230210-170042.yaml
+++ b/.changes/unreleased/NOTES-20230210-170042.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'provider: Rewritten to use the [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework)'
+time: 2023-02-10T17:00:42.625932-05:00
+custom:
+  Issue: "96"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 2.3.0 (February 22, 2023)
-
-NOTES:
-
-* provider: Rewritten to use the [`terraform-plugin-framework`](https://www.terraform.io/plugin/framework) ([#96](https://github.com/hashicorp/terraform-provider-cloudinit/issues/96))
-
 ## 2.2.0 (February 19, 2021)
 
 Binary releases of this provider will now include the darwin-arm64 platform. This version contains no further changes.


### PR DESCRIPTION
### Background
- We ran into a problem releasing `v2.3.0` of cloudinit due to permission issues in the release workflow fixed in #100 
- We were unsure if changie would no-op on the changelog batch/merge, but it [failed](https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/4243943598) with `version already exists: .changes/2.3.0.md`

### Notes
- This reverts the original changelog commit 933c43ffa14b0a7f226057b49a0631c815d95feb for `v2.3.0`.

```bash
git revert 933c43ffa14b0a7f226057b49a0631c815d95feb
```