### PR TITLE
Fixed handling of unknown values in `part` blocks

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230222-152308.yaml
+++ b/.changes/unreleased/BUG FIXES-20230222-152308.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'cloudinit_config: Fixed handling of unknown values in `part` blocks'
+time: 2023-02-22T15:23:08.11379-05:00
+custom:
+  Issue: "103"

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -8,7 +8,7 @@ description: |-
 
 # cloudinit_config (Resource)
 
-~> **This resource is deprecated** Please use the [cloudinit_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/cloudinit_config)
+~> **This resource is deprecated** Please use the [cloudinit_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config)
   data source instead.
 
 Renders a [multi-part MIME configuration](https://cloudinit.readthedocs.io/en/latest/explanation/format.html#mime-multi-part-archive) for use with [cloud-init](https://cloudinit.readthedocs.io/en/latest/).

--- a/internal/provider/data_source_cloudinit_config.go
+++ b/internal/provider/data_source_cloudinit_config.go
@@ -28,7 +28,7 @@ func (d *configDataSource) ValidateConfig(ctx context.Context, req datasource.Va
 		return
 	}
 
-	resp.Diagnostics.Append(cloudinitConfig.validate()...)
+	resp.Diagnostics.Append(cloudinitConfig.validate(ctx)...)
 }
 
 func (d *configDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/provider/data_source_cloudinit_config_test.go
+++ b/internal/provider/data_source_cloudinit_config_test.go
@@ -260,6 +260,7 @@ func TestConfigDataSource_UpgradeFromVersion2_2_0(t *testing.T) {
 	}
 }
 
+// This test ensures that unknown values are being handled properly in the `part` block
 // https://github.com/hashicorp/terraform-provider-cloudinit/issues/102
 func TestConfigDataSource_HandleUnknown(t *testing.T) {
 	testCases := []struct {

--- a/internal/provider/data_source_cloudinit_config_test.go
+++ b/internal/provider/data_source_cloudinit_config_test.go
@@ -259,3 +259,54 @@ func TestConfigDataSource_UpgradeFromVersion2_2_0(t *testing.T) {
 		})
 	}
 }
+
+// https://github.com/hashicorp/terraform-provider-cloudinit/issues/102
+func TestConfigDataSource_HandleUnknown(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		DataSourceBlock string
+		Expected        string
+	}{
+		{
+			"issue 102 - handle unknown in validate caused by variable",
+			`
+			variable "config_types" {
+				default = ["text/cloud-config", "text/cloud-config"]
+			}
+			  
+			data "cloudinit_config" "foo" {
+				gzip          = true
+				base64_encode = true
+				
+				dynamic "part" {
+				  for_each = var.config_types
+				  content {
+					content_type = part.value
+					content      = <<-EOT
+					#cloud-config
+					test: ${part.value}
+					EOT
+				  }
+				}
+			}
+			`,
+			"H4sIAAAAAAAA/3LOzytJzSvRDaksSLVSyC3NKcksSCwq0c/NrEhNsVZIyi/NS0ksqrRV8vX0dXXyD/VzcQyKVOIC8XTDUouKM/PzrBQM9Qx4uXi5dHWRFfFywc0uSswrTkst0nXNS85PycxLt1IwT8osQVIAtrwktaJEPzknvzRFNzk/Ly0znZfLNzM3FcMaZWQ1XCWpxSVY9A525+jq8nIBAgAA//821u5zfAEAAA==",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			r.UnitTest(t, r.TestCase{
+				Steps: []r.TestStep{
+					{
+						ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+						Config:                   tt.DataSourceBlock,
+						Check: r.ComposeTestCheckFunc(
+							r.TestCheckResourceAttr("data.cloudinit_config.foo", "rendered", tt.Expected),
+						),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/provider/resource_cloudinit_config.go
+++ b/internal/provider/resource_cloudinit_config.go
@@ -34,7 +34,7 @@ func (r *configResource) ValidateConfig(ctx context.Context, req resource.Valida
 		return
 	}
 
-	resp.Diagnostics.Append(cloudinitConfig.validate()...)
+	resp.Diagnostics.Append(cloudinitConfig.validate(ctx)...)
 }
 
 func (r *configResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/resource_cloudinit_config_test.go
+++ b/internal/provider/resource_cloudinit_config_test.go
@@ -260,6 +260,7 @@ func TestConfigResource_UpgradeFromVersion2_2_0(t *testing.T) {
 	}
 }
 
+// This test ensures that unknown values are being handled properly in the `part` block
 // https://github.com/hashicorp/terraform-provider-cloudinit/issues/102
 func TestConfigResource_HandleUnknown(t *testing.T) {
 	testCases := []struct {

--- a/templates/resources/config.md.tmpl
+++ b/templates/resources/config.md.tmpl
@@ -6,7 +6,7 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
-~> **This resource is deprecated** Please use the [cloudinit_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/cloudinit_config)
+~> **This resource is deprecated** Please use the [cloudinit_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config)
   data source instead.
 
 {{ .Description }}


### PR DESCRIPTION
- Closes #102 
- Updates a broken link in the `cloudinit` documentation

### Background
The `configModel.Parts` field was using a struct directly instead of the plugin framework `types.List` type, this caused a bug when handling unknown values. The validate method seemed to be the culprit for this specific bug, as validation is done in an "offline" [mode](https://developer.hashicorp.com/terraform/cli/commands/validate#:~:text=Validate%20runs%20checks%20that%20verify%20whether%20a%20configuration%20is%20syntactically%20valid%20and%20internally%20consistent%2C%20regardless%20of%20any%20provided%20variables%20or%20existing%20state), that does not include variables. This combined with a `dynamic` block can mark `Parts` as unknown.

I was unable to recreate the issue with the config provided in #102, but was able to recreate using a dynamic block as seen in the acceptance tests.

### Test errors before code change:
```bash
=== RUN   TestConfigDataSource_HandleUnknown/issue_102_-_handle_unknown_in_validate_caused_by_variable
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/data_source_cloudinit_config_test.go:299: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Value Conversion Error

          with data.cloudinit_config.foo,
          on terraform_plugin_test.tf line 6, in data "cloudinit_config" "foo":
           6:                   data "cloudinit_config" "foo" {

        An unexpected error was encountered trying to build a value. This is always
        an error in the provider. Please report the following to the provider
        developer:

        Received unknown value, however the target type cannot handle unknown values.
        Use the corresponding `types` package type or a custom type that handles
        unknown values.

        Path: part
        Target Type: []provider.configPartModel
        Suggested Type: basetypes.ListValue
```
```bash
=== RUN   TestConfigResource_HandleUnknown/issue_102_-_handle_unknown_in_validate_caused_by_variable
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/resource_cloudinit_config_test.go:299: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Value Conversion Error

          with cloudinit_config.foo,
          on terraform_plugin_test.tf line 6, in resource "cloudinit_config" "foo":
           6:                   resource "cloudinit_config" "foo" {

        An unexpected error was encountered trying to build a value. This is always
        an error in the provider. Please report the following to the provider
        developer:

        Received unknown value, however the target type cannot handle unknown values.
        Use the corresponding `types` package type or a custom type that handles
        unknown values.

        Path: part
        Target Type: []provider.configPartModel
        Suggested Type: basetypes.ListValue
```