### PR TITLE
Fix regression of empty content strings in `part` block

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230223-151930.yaml
+++ b/.changes/unreleased/BUG FIXES-20230223-151930.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'cloudinit_config: Remove length validation to allow empty content string in
+  part blocks'
+time: 2023-02-23T15:19:30.197062-05:00
+custom:
+  Issue: "105"

--- a/internal/provider/data_source_cloudinit_config.go
+++ b/internal/provider/data_source_cloudinit_config.go
@@ -49,9 +49,6 @@ func (d *configDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 							MarkdownDescription: "A MIME-style content type to report in the header for the part. Defaults to `text/plain`",
 						},
 						"content": schema.StringAttribute{
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-							},
 							Required:            true,
 							MarkdownDescription: "Body content for the part.",
 						},

--- a/internal/provider/data_source_cloudinit_config_test.go
+++ b/internal/provider/data_source_cloudinit_config_test.go
@@ -130,6 +130,42 @@ func TestConfigDataSourceRender(t *testing.T) {
 			}`,
 			"H4sIAAAAAAAA/2TNuwrCQBCF4X5h32FJP0YrIWLhJYVFFEQFy1xGM5DMhtkJJG8vWkjQ8sDP+XaeFVnhMnaYuLZvlLpcNG5pwGrlCt9zlcu4jrJDlm5P1+N+c75H5r3ghhLIc+IWs7k11gBMI2u+35JzeKBAyqWviJ+JWxakk+CDKw4aDxBqbJpQCnVqTUYt/jk1jlqj4K8IYM0rAAD//0u6BO3QAAAA",
 		},
+		// Initial fix of panic when part block wasn't parsable
+		// https://github.com/hashicorp/terraform/issues/13572
+		//
+		// Move to framework fixed parsing error, but introduced incorrect validation,  empty content is valid
+		// https://github.com/hashicorp/terraform-provider-cloudinit/issues/104
+		{
+			"empty content field in part block",
+			`data "cloudinit_config" "foo" {
+				part {
+					content = ""
+				}
+			}`,
+			"H4sIAAAAAAAA/3LOzytJzSvRDaksSLVSyC3NKcksSCwq0c/NrEhNsVZIyi/NS0ksqrRV8vX0dXXyD/VzcQyKVOIC8XTDUouKM/PzrBQM9Qx4uXi5dHWRFfFywc0uSswrTkst0nXNS85PycxLt1IwT8osQVIAtrwktaJEvyAnMTOPl8s3MzcVw3x0G3R1ebkAAQAA///dakG4wAAAAA==",
+		},
+		{
+			"empty content field in one part block, multiple part blocks",
+			`data "cloudinit_config" "foo" {
+				gzip = false
+				base64_encode = false
+
+				part {
+					content_type = "text/cloud-config"
+					content = "abc"
+				}
+
+				part {
+					content = ""
+				}
+
+				part {
+					content_type = "text/cloud-config"
+					content = ""
+				}
+			}`,
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/cloud-config\r\nMime-Version: 1.0\r\n\r\nabc\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/plain\r\nMime-Version: 1.0\r\n\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/cloud-config\r\nMime-Version: 1.0\r\n\r\n\r\n--MIMEBOUNDARY--\r\n",
+		},
 	}
 
 	for _, tt := range testCases {
@@ -149,22 +185,12 @@ func TestConfigDataSourceRender(t *testing.T) {
 	}
 }
 
-// https://github.com/hashicorp/terraform/issues/13572
 func TestConfigDataSourceRender_handleErrors(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		DataSourceBlock string
 		ErrorMatch      *regexp.Regexp
 	}{
-		{
-			"empty content field in part block",
-			`data "cloudinit_config" "foo" {
-				part {
-					content = ""
-				}
-			}`,
-			regexp.MustCompile("content string length must be at least 1"),
-		},
 		{
 			"base64 can't be false when gzip is true",
 			`data "cloudinit_config" "foo" {

--- a/internal/provider/resource_cloudinit_config.go
+++ b/internal/provider/resource_cloudinit_config.go
@@ -59,9 +59,6 @@ func (r *configResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							MarkdownDescription: "A MIME-style content type to report in the header for the part. Defaults to `text/plain`",
 						},
 						"content": schema.StringAttribute{
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-							},
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},


### PR DESCRIPTION
- Closes #104 

## Background
There was a regression test for ensuring a failure on a `part` block with empty content in `v2.2.0` introduced here: https://github.com/hashicorp/terraform/pull/13581 . When we ported `cloudinit` over to the `terraform-plugin-framework`, this was perceived as a test to protect from empty content strings, so we replaced this with a [string validator](https://github.com/hashicorp/terraform-provider-cloudinit/blob/cd3914f15cd66d258248df1fc36ca97359b2dcfa/internal/provider/data_source_cloudinit_config.go#L53) to ensure it was not empty.

This test was actually introduced to ensure that the `part` block was [parsed correctly](https://github.com/hashicorp/terraform/issues/13572) and would not panic. In `v2.2.0` an empty content string and one part block would not be parsed correctly, resulting in an error:
```terraform
data "cloudinit_config" "foo" {
   part {
      content = ""
   }
}
```

```bash
│ Error: Unable to parse parts in cloudinit resource declaration
│ 
│   with data.cloudinit_config.cloud_config,
│   on main.tf line 1, in data "cloudinit_config" "cloud_config":
│    1: data "cloudinit_config" "cloud_config" {
```
This panic/parse issue has been fixed by the act of moving to the plugin-framework, so ensuring a non-empty `content` field was not an original requirement. This PR removes that validation

### Test failures before fix
```bash
=== RUN   TestConfigDataSourceRender/empty_content_field_in_part_block
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/data_source_cloudinit_config_test.go:173: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid Attribute Value Length

          with data.cloudinit_config.foo,
          on terraform_plugin_test.tf line 3, in data "cloudinit_config" "foo":
           3:                                   content = ""

        Attribute part[0].content string length must be at least 1, got: 0
=== RUN   TestConfigDataSourceRender/empty_content_field_in_one_part_block,_multiple_part_blocks
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/data_source_cloudinit_config_test.go:173: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid Attribute Value Length

          with data.cloudinit_config.foo,
          on terraform_plugin_test.tf line 11, in data "cloudinit_config" "foo":
          11:                                   content = ""

        Attribute part[1].content string length must be at least 1, got: 0

        Error: Invalid Attribute Value Length

          with data.cloudinit_config.foo,
          on terraform_plugin_test.tf line 16, in data "cloudinit_config" "foo":
          16:                                   content = ""

        Attribute part[2].content string length must be at least 1, got: 0
```
```bash
=== RUN   TestConfigResourceRender/empty_content_field_in_part_block
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/resource_cloudinit_config_test.go:173: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid Attribute Value Length

          with cloudinit_config.foo,
          on terraform_plugin_test.tf line 3, in resource "cloudinit_config" "foo":
           3:                                   content = ""

        Attribute part[0].content string length must be at least 1, got: 0
=== RUN   TestConfigResourceRender/empty_content_field_in_one_part_block,_multiple_part_blocks
    /Users/austin.valle/code/terraform-provider-cloudinit/internal/provider/resource_cloudinit_config_test.go:173: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid Attribute Value Length

          with cloudinit_config.foo,
          on terraform_plugin_test.tf line 11, in resource "cloudinit_config" "foo":
          11:                                   content = ""

        Attribute part[1].content string length must be at least 1, got: 0

        Error: Invalid Attribute Value Length

          with cloudinit_config.foo,
          on terraform_plugin_test.tf line 16, in resource "cloudinit_config" "foo":
          16:                                   content = ""

        Attribute part[2].content string length must be at least 1, got: 0
```