### PR TITLE
Add changelogs for `v2.3.3` release

### DIFF
--- a/.changes/unreleased/NOTES-20231127-094724.yaml
+++ b/.changes/unreleased/NOTES-20231127-094724.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: This release introduces no functional changes. It does however include dependency
+  updates which address upstream CVEs.
+time: 2023-11-27T09:47:24.494138-05:00
+custom:
+  Issue: "186"


### PR DESCRIPTION
Added a new changelog entry for the upcoming `v2.3.3` patch release and removed the Go upgrade changelog (since this isn't an external Go module)