### PR TITLE
Update build Action to resolve warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: 'go.mod'
@@ -43,7 +43,7 @@ jobs:
       product-prerelease-version: ${{ steps.set-product-version.outputs.prerelease-product-version }}
       product-minor-version: ${{ steps.set-product-version.outputs.minor-product-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set Product version
         id: set-product-version
         uses: hashicorp/actions-set-product-version@v2
@@ -55,7 +55,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -88,7 +88,7 @@ jobs:
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: hashicorp/actions-go-build@v1
         env:
           CGO_ENABLED: 0
@@ -126,7 +126,7 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: hashicorp/actions-go-build@v1
         env:
           CGO_ENABLED: 0

--- a/.release/oss-release-metadata.hcl
+++ b/.release/oss-release-metadata.hcl
@@ -1,0 +1,4 @@
+url_source_repository         = "https://github.com/hashicorp/terraform-provider-cloudinit"
+url_project_website           = "https://registry.terraform.io/providers/hashicorp/cloudinit"
+url_license                   = "https://github.com/hashicorp/terraform-provider-cloudinit/blob/main/LICENSE"
+url_release_notes             = "https://github.com/hashicorp/terraform-provider-cloudinit/blob/main/CHANGELOG.md"

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,7 @@
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = false
+	nvd          = false
+}

--- a/.release/terraform-provider-cloudinit-artifacts.hcl
+++ b/.release/terraform-provider-cloudinit-artifacts.hcl
@@ -1,0 +1,16 @@
+schema = 1
+artifacts {
+  zip = [
+    "terraform-provider-cloudinit_${version}_darwin_amd64.zip",
+    "terraform-provider-cloudinit_${version}_darwin_arm64.zip",
+    "terraform-provider-cloudinit_${version}_freebsd_386.zip",
+    "terraform-provider-cloudinit_${version}_freebsd_amd64.zip",
+    "terraform-provider-cloudinit_${version}_freebsd_arm.zip",
+    "terraform-provider-cloudinit_${version}_linux_386.zip",
+    "terraform-provider-cloudinit_${version}_linux_amd64.zip",
+    "terraform-provider-cloudinit_${version}_linux_arm.zip",
+    "terraform-provider-cloudinit_${version}_linux_arm64.zip",
+    "terraform-provider-cloudinit_${version}_windows_386.zip",
+    "terraform-provider-cloudinit_${version}_windows_amd64.zip",
+  ]
+}


### PR DESCRIPTION
This change is to address warnings in build Action runs such as https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/11938499015