### PR TITLE
Configure release orchestration, step 1 of n

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,0 +1,46 @@
+# Reference: https://github.com/hashicorp/crt-core-helloworld/blob/main/.release/ci.hcl (private repository)
+
+schema = "2"
+
+project "terraform-provider-cloudinit" {
+  // team is currently unused and has no meaning
+  // but is required to be non-empty by CRT orchestator
+  team = "_UNUSED_"
+
+  slack {
+    notification_channel = "C02M018DV27" // #feed-tf-devex
+  }
+
+  github {
+    organization     = "hashicorp"
+    repository       = "terraform-provider-cloudinit"
+    release_branches = ["main"]
+  }
+}
+
+event "build" {
+  action "build" {
+    organization = "hashicorp"
+    repository   = "terraform-provider-cloudinit"
+    workflow     = "build"
+  }
+}
+
+event "prepare" {
+  # `prepare` is the Common Release Tooling (CRT) artifact processing workflow.
+  # It prepares artifacts for potential promotion to staging and production.
+  # For example, it scans and signs artifacts.
+
+  depends = ["build"]
+
+  action "prepare" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,7 +1,11 @@
+# Reference: https://github.com/hashicorp/security-scanner/blob/main/CONFIG.md#binary (private repository)
+
 binary {
-	secrets      = true
-	go_modules   = true
-	osv          = true
-	oss_index    = false
-	nvd          = false
+  secrets {
+    all = true
+  }
+  go_modules   = true
+  osv          = true
+  oss_index    = false
+  nvd          = false
 }


### PR DESCRIPTION
This change adds .release/ci.hcl. This file is "read by the crt-orchestrator app and should include the events required to trigger the common workflows responsible for processing the artifacts built in the previous phase."

For "step 1 of n," we simply add the common `prepare` workflow, which crt-orchestrator will run after a successful `build` workflow run. The only side effect of `prepare` is upload to HashiCorp's artifact store. That keeps this change a safe distance away from existing staging and production releases.