### PR TITLE
Configure new-style releases

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,7 +8,7 @@ project "terraform-provider-cloudinit" {
   team = "_UNUSED_"
 
   slack {
-    notification_channel = "C02M018DV27" // #feed-tf-devex
+    notification_channel = "C02BASDVCDT" // #feed-terraform-sdk
   }
 
   github {

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -44,3 +44,47 @@ event "prepare" {
     on = "fail"
   }
 }
+
+event "trigger-staging" {
+}
+
+event "promote-staging" {
+  action "promote-staging" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging"
+    depends      = null
+    config       = "oss-release-metadata.hcl"
+  }
+
+  depends = ["trigger-staging"]
+
+  notification {
+    on = "always"
+  }
+
+  promotion-events {
+  }
+}
+
+event "trigger-production" {
+}
+
+event "promote-production" {
+  action "promote-production" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production"
+    depends      = null
+    config       = ""
+  }
+
+  depends = ["trigger-production"]
+
+  notification {
+    on = "always"
+  }
+
+  promotion-events {
+  }
+}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,7 +14,7 @@ project "terraform-provider-cloudinit" {
   github {
     organization     = "hashicorp"
     repository       = "terraform-provider-cloudinit"
-    release_branches = ["main"]
+    release_branches = ["main", "release/**"]
   }
 }
 

--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,2 +1,0 @@
-url_source_repository      = "https://github.com/hashicorp/terraform-provider-cloudinit"
-url_license                = "https://github.com/hashicorp/terraform-provider-cloudinit/blob/main/LICENSE"


### PR DESCRIPTION
This change:

* Updates the channel for Common Release Tooling notifications
* Adds staging and production events to `.release/ci.hcl`. These events will not run automatically, so no switch is being turned on here :)
* Allow releases from `release/*` branches; some providers are released from branches, and I see no harm in allowing it (even if unused) in any provider & reducing variation in `ci.hcl` content for ease of adoption