### PR TITLE
Updates for Common Release Tooling onboarding

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -20,6 +20,8 @@ project "terraform-provider-cloudinit" {
 
 event "build" {
   action "build" {
+    depends = ["merge"]
+
     organization = "hashicorp"
     repository   = "terraform-provider-cloudinit"
     workflow     = "build"
@@ -62,9 +64,6 @@ event "promote-staging" {
   notification {
     on = "always"
   }
-
-  promotion-events {
-  }
 }
 
 event "trigger-production" {
@@ -83,8 +82,5 @@ event "promote-production" {
 
   notification {
     on = "always"
-  }
-
-  promotion-events {
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -18,6 +18,9 @@ project "terraform-provider-cloudinit" {
   }
 }
 
+event "merge {
+}
+
 event "build" {
   action "build" {
     depends = ["merge"]


### PR DESCRIPTION
Since this repo is a reference example for onboarding to Common Release Tooling, let's make a couple things nicer.

- promotion-events can be omitted when empty
- build-on-merge adds a useful feedback loop