### PR TITLE
Replace golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - godot
     - gofmt
@@ -19,10 +19,10 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting
 
 run:
   # Prevent false positive timeouts in CI


### PR DESCRIPTION
From https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/13291030346/job/37111639962?pr=308

```
 level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  level=warning msg="The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting."
  level=error msg="[linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports."
  
  Error: golangci-lint exit with code 7
```