### PR TITLE
chore: Update CRT build to run on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,7 @@ name: build
 #
 #   https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
 #
-#on: [workflow_dispatch, push]
-
-# By dispatch only in development
-on: [workflow_dispatch]
+on: [workflow_dispatch, push]
 
 env:
   PKG_NAME: "terraform-provider-cloudinit"


### PR DESCRIPTION
I believe we can do this now that cloudinit has been successfully released via CRT 👍🏻 