### PR TITLE
Upload registry manifest as an Actions artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,29 @@ jobs:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
+  # $ unzip -l tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
+  # Archive:  tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
+  #   terraform-provider-cloudinit_2.3.6-alpha1.json
+  upload-terraform-registry-manifest-file:
+    needs: set-product-version
+    runs-on: ubuntu-latest
+    outputs:
+      filepath: ${{ steps.terraform-registry-manifest.outputs.filename }}
+    steps:
+      - name: "Checkout directory"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: ${{ env.PKG_NAME }}
+      - name: Build filename
+        id: terraform-registry-manifest
+        run: |
+          cp ${{ env.PKG_NAME }}/terraform-registry-manifest.json "${{ env.PKG_NAME }}_${{ needs.set-product-version.outputs.product-version }}.json"
+          echo "filename=${{ env.PKG_NAME }}_${{ needs.set-product-version.outputs.product-version }}.json" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: terraform-registry-manifest.json
+          path: ${{ steps.terraform-registry-manifest.outputs.filename }}
+
   build-other:
     needs:
       - get-go-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,10 @@ jobs:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  # $ unzip -l tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
-  # Archive:  tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
-  #   terraform-provider-cloudinit_2.3.6-alpha1.json
+  # This job uploads an Actions artifact named terraform-registry-manifest.json.zip.
+  # The artifact contains a single file with a filename that Terraform Registry expects
+  # (example: terraform-provider-cloudinit_2.3.6-alpha1.json) and contents identical
+  # to the terraform-registry-manifest.json file in the repository.
   upload-terraform-registry-manifest-file:
     needs: set-product-version
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a step to the Build workflow that uploads this repo's Terraform Registry manifest file as an Actions artifact. The intended consumer of this artifact is the Common Release Tooling (CRT) Prepare workflow.

We will need to test the updated Build in integration with Prepare to verify whether Prepare recognizes the manifest file as an artifact type and uploads it to the places it needs to be uploaded.

Tested locally with nektos/act:

```
$ act --container-architecture linux/amd64 --platform linux=ghcr.io/catthehacker/ubuntu:full-22.04 --pull=false -W .github/workflows/build.yml --artifact-server-path=tmp

... all the output ...

$ grep manifest [ all the output ]

[build/upload-terraform-registry-manifest-file]   ⚙  ::set-output:: filename=terraform-provider-cloudinit_2.3.6-alpha1.json
[build/upload-terraform-registry-manifest-file]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.7/x64/bin/node /var/run/act/actions/actions-upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08/dist/upload/index.js] user= workdir=
| Artifact terraform-registry-manifest.json.zip successfully finalized. Artifact ID 3281509071
| Artifact terraform-registry-manifest.json has been successfully uploaded! Final size is 271 bytes. Artifact ID is 3281509071
[build/upload-terraform-registry-manifest-file]   ⚙  ::set-output:: artifact-id=3281509071
[build/upload-terraform-registry-manifest-file]   ⚙  ::set-output:: artifact-digest=6aea5b37e9e1d9348e8fa84533b70c1a311ff67bbe68e74a78c0905850ed8051
[build/upload-terraform-registry-manifest-file]   ⚙  ::set-output:: artifact-url=https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/1/artifacts/3281509071
[build/upload-terraform-registry-manifest-file] 🏁  Job succeeded

$ find tmp/1
tmp/1
tmp/1/metadata.json
tmp/1/metadata.json/metadata.json.zip
tmp/1/terraform-registry-manifest.json
tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip

$ unzip -l tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
Archive:  tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
       82  03-04-2025 12:36   terraform-provider-cloudinit_2.3.6-alpha1.json
---------                     -------
       82                     1 file

$ unzip -p tmp/1/terraform-registry-manifest.json/terraform-registry-manifest.json.zip
{
    "version": 1,
    "metadata": {
        "protocol_versions": ["5.0"]
    }
}
```