### PR TITLE
Fix manifest filename string-building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,7 @@ jobs:
           echo "### Terraform Registry manifest" >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
           cat "$source" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:


### PR DESCRIPTION
Fixes this issue found in [a workflow run](https://github.com/hashicorp/terraform-provider-cloudinit/actions/runs/13723300403/job/38383671205#step:4:12) while testing:

<img width="1231" alt="Screenshot 2025-03-07 at 12 11 30 PM" src="https://github.com/user-attachments/assets/f70c1b52-139f-41db-8676-2f079dd2755e" />

This PR tells actions/upload-artifact that it's an error if no files are found to upload.

And it fixes the string-building of the `destination` file path to correct the issue.
