### PR TITLE
Add a pre-promotion workflow to promote-staging

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -64,6 +64,18 @@ event "promote-staging" {
 
   depends = ["trigger-staging"]
 
+  promotion-events {
+
+    // Download Registry manifest from Artifactory staging repo
+    // and upload to staging Releases bucket
+    pre-promotion {
+      organization = "hashicorp"
+      repository   = "action-upload-terraform-registry-manifest"
+      workflow     = "upload.yml"
+    }
+
+  }
+
   notification {
     on = "always"
   }


### PR DESCRIPTION
The next step in testing Registry manifest upload. Continue to operate within the safety net of `promote-staging`. Configure an Action in [an internal repo](https://github.com/hashicorp/action-upload-terraform-registry-manifest) as a pre-promotion workflow. The workflow will upload the manifest to the staging Releases site -- not production.