### PR TITLE
Fix post-promotion workflow name

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -75,7 +75,7 @@ event "promote-staging" {
     post-promotion {
       organization = "hashicorp"
       repository   = "action-upload-terraform-registry-manifest"
-      workflow     = "upload.yml"
+      workflow     = "upload"
     }
 
   }


### PR DESCRIPTION
Workflow name, not filename. [Reference](https://github.com/hashicorp/actions-dispatch-repo-workflow?tab=readme-ov-file#examples) (internal repo).