### PR TITLE
fix: critical go CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-cloudinit
 
-go 1.23.7
+go 1.23.12
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.15.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.23.7
+go 1.23.12
 
 require (
 	github.com/hashicorp/copywrite v0.22.0


### PR DESCRIPTION
## Related Issue

N/A

## Description

Bumping the go version would fix the Critical vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2025-22871

Details from [here](https://pkg.go.dev/vuln/GO-2025-3563):

> The net/http package improperly accepts a bare LF as a line terminator in chunked data chunk-size lines. This can permit request smuggling if a net/http server is used in conjunction with a server that incorrectly accepts a bare LF as part of a chunk-ext.

Affected versions:
> before go1.23.8, from go1.24.0-0 before go1.24.2

So I picked the latest 1.23 go version

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

N/A
